### PR TITLE
Use double quotes in ENV sample

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,4 +1,4 @@
-WORDPRESS_TITLE=Skela Site
+WORDPRESS_TITLE="Skela Site"
 WORDPRESS_THEME_NAME=skela
 WORDPRESS_URL=https://skela.ups.dock
 WORDPRESS_ADMIN_USER=admin


### PR DESCRIPTION
## Changes

Surround sample site name in `.env.sample` with double quotes to avoid error