### PR TITLE
Update WordPress after install

### DIFF
--- a/bin/install
+++ b/bin/install
@@ -26,6 +26,11 @@ echo
 docker-compose exec wordpress wp plugin activate --all
 echo
 
+echo "Updating WordPress..."
+echo
+docker-compose exec wordpress wp core update
+echo
+
 echo "-------------------------------"
 echo "Install completed successfully!"
 echo "-------------------------------"


### PR DESCRIPTION
Docker likes using cache and it's tricky to disable. We'll just make sure WordPress is updated after install.

## Changes

Add `wp core update` to end of install script