### PR TITLE
Update calls to Timber::get_context in anticipation of Timber 2.0

### DIFF
--- a/404.php
+++ b/404.php
@@ -4,6 +4,7 @@
  *
  */
 
+$context = Timber::context();
 
 // Page title.
 $context['wp_title'] = '404 Not Found';

--- a/front-page.php
+++ b/front-page.php
@@ -5,7 +5,7 @@
 
 use Skela\Repositories\PostTypeRepository;
 
-$context = Timber::get_context();
+$context = Timber::context();
 
 $postTypeRepo = new PostTypeRepository();
 $latestPosts = $postTypeRepo->latestPosts(10, null, [], null)->get();

--- a/single.php
+++ b/single.php
@@ -3,7 +3,7 @@
  * Single post / article
  */
 
-$context = Timber::get_context();
+$context = Timber::context();
 
 // Get post
 $post = Timber::get_post();

--- a/src/Blocks/RelatedArticles/RelatedArticles.php
+++ b/src/Blocks/RelatedArticles/RelatedArticles.php
@@ -62,7 +62,7 @@ class RelatedArticles
      */
     public function renderRelatedArticlesBlock($block, $content, $is_preview)
     {
-        $context = Timber::get_context();
+        $context = Timber::context();
         $context['relatedArticlesHeader'] = get_field('header_text');
         $relatedArticles = get_field('chosen_articles');
         $relatedArticlesIDs = [];

--- a/src/Blocks/SampleACFBlock/ACFBlock.php
+++ b/src/Blocks/SampleACFBlock/ACFBlock.php
@@ -54,7 +54,7 @@ class ACFBlock
     public function renderACFBlock($block, $content, $is_preview)
     {
         // If the block renders info from TimberTheme, TimberSite, etc., then uncomment the following:
-        // $context = Timber::get_context();
+        // $context = Timber::context();
 
         $context['some_headline'] = get_field('some_headline');
         $context['some_text'] = get_field('some_text');


### PR DESCRIPTION
## Changes

Updated calls from `Timber::get_context()` to `Timber::context()` in anticipation of Timber 2.0.

## How To Test

In a browser, request the front page of the site, a single blog post and check that the context is available. In a Gutenberg editor, use the Related Articles and ACF Blocks and ensure they load with the context available.
