### PR TITLE
Remove autoprefixer options from webpack config

### DIFF
--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -13,13 +13,6 @@ mix
   .js('src/Blocks/Blocks.js', 'dist/blocks.build.js')
   .sass('src/Blocks/editor.scss', 'dist/block-editor.build.css')
   .copy('src/Blocks/**/*.png', 'dist/block-editor-images/')
-  .options({
-    autoprefixer: {
-      options: {
-        browsers: ['defaults', '> .5% in US', 'last 3 iOS versions', 'ie >= 10'],
-      },
-    },
-  })
   .extract()
   .autoload({
     jquery: ['$', 'window.jQuery'],


### PR DESCRIPTION
## Changes

Removes autoprefixer options from webpack config. This was causing this error:

```
Replace Autoprefixer browsers option to Browserslist config.
  Use browserslist key in package.json or .browserslistrc file.

  Using browsers option cause some error. Browserslist config
  can be used for Babel, Autoprefixer, postcss-normalize and other tools.

  If you really need to use option, rename it to overrideBrowserslist.

  Learn more at:
  https://github.com/browserslist/browserslist#readme
  https://twitter.com/browserslist
```

Oddly, replacing the `browsers` with `browserlist` as recommended caused another error. In checking Laravel 4.0 docs, it seems like the defaults should suffice for the default Skela theme:

https://laravel-mix.com/docs/4.0/css-preprocessors#postcss-plugins
