### PR TITLE
Prevent jQuery from being removed from prod builds

### DIFF
--- a/src/Managers/ThemeManager.php
+++ b/src/Managers/ThemeManager.php
@@ -59,11 +59,6 @@ class ThemeManager
      */
     public function enqueue()
     {
-        // don't use WordPress jquery in production. (admin bar and wordpress debug bar needs it in development)
-        if (WP_ENV != 'development') {
-            wp_deregister_script('jquery');
-        }
-
         // Remove default Gutenberg CSS
         wp_deregister_style('wp-block-library');
 


### PR DESCRIPTION
## Changes

Remove conditional that deregisters the jQuery script in prod
