### PR TITLE
Fixes code splitting Webpack issue

### DIFF
--- a/bin/rename-theme
+++ b/bin/rename-theme
@@ -42,6 +42,7 @@ replace_lowercase() {
   eval `sed -i '' "s/skela.ups.dock/${LOWERCASE}.ups.dock/" package.json`
   eval `sed -i '' "s/#skela/#${LOWERCASE}/" README.md`
   eval `sed -i '' "s/skela.ups.dock/${LOWERCASE}.ups.dock/" README.md`
+  eval `sed -i '' "s/skela/${LOWERCASE}/" webpack.config.js`
   eval `sed -i '' "s/skela.ups.dock/${LOWERCASE}.ups.dock/" webpack.config.js`
   eval `sed -i '' "s/skela/${LOWERCASE}/" bin/composer`
   eval `sed -i '' "s/skela/${LOWERCASE}/" src/Blocks/SampleBlock/sample-block.js`

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -13,16 +13,11 @@ $(document).ready(() => {
   // This is an example of how to do code splitting. The JS in this
   // referenced file will only be loaded on that page. Good for
   // when you have a large amount of JS only needed in one place
-  /*
-    if ($("#js-process").length > 0) {
-        require.ensure(
-            ["./pages/process"],
-            require => {
-                const Process = require("./pages/process").default;
-                this.process = new Process();
-            },
-            "process"
-        );
-    }
-    */
+
+  // if ($('#js-process').length > 0) {
+  //   import(/* webpackChunkName: "process" */ './pages/process').then(module => {
+  //     const Process = module.default;
+  //     this.process = new Process();
+  //   });
+  // }
 });

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,8 +15,9 @@ module.exports = {
   },
 
   output: {
-    path: path.resolve(__dirname, 'dist'),
     filename: '[name].js',
+    path: path.resolve(__dirname, 'dist'),
+    publicPath: '/wp-content/themes/skela/dist/',
   },
 
   module: {


### PR DESCRIPTION
## Changes

Ports Webpack code splitting issue fixes to Skela

- Updates `webpack.config.js` to include a `publicPath` for outputted chunks
- Updates example in `app.js` for Webpack code splitting
- Updates `./bin/rename-theme` to update new `publicPath` in `webpack.config.js`

## How To Test

- [x] Requires restart: `./bin/start`

1. Update `app.js` to dynamically import `Menu`:
```diff
- new Menu();
+ if (document.querySelector('body')) {
+   import(/* webpackChunkName: "menu" */ './components/menu').then(module => {
+     const Menu = module.default;
+     new Menu();
+   });
+ }
```
2. Check the console and confirm the skeleton emoji is being logged
3. Check the Network tab and confirm `menu.js` is being loaded
4. Update the conditional to always be false:
```diff
- if (document.querySelector('body')) {
+ if (!document.querySelector('body')) {
```
5. Confirm 2 and 3 are now false