### PR TITLE
Fix browsersync https proxying

### DIFF
--- a/docker/scripts/setup.sh
+++ b/docker/scripts/setup.sh
@@ -17,6 +17,16 @@ if (strpos(\$_SERVER['HTTP_X_FORWARDED_PROTO'], 'https') !== false) {
 	\$_SERVER['HTTPS'] = 'on';
 }
 
+/* Set home / site URL based on incoming request for local development to avoid SSL headaches */
+\$schema = \$_SERVER['HTTPS'] === 'on' ? 'https' : 'http';
+\$host = parse_url('$WORDPRESS_URL', PHP_URL_HOST);
+\$port = parse_url('$WORDPRESS_URL', PHP_URL_PORT);
+\$path = parse_url('$WORDPRESS_URL', PHP_URL_PATH);
+\$port = \$port ? ":$port" : '';
+\$url = "\$schema://\${host}\${port}\${path}";
+define('WP_HOME',    \$url);
+define('WP_SITEURL', \$url);
+
 /* Logging */
 define('WP_DEBUG', true);
 define('WP_DEBUG_LOG', '/var/www/html/logs/error.log');


### PR DESCRIPTION
## Changes

Ports changes from https://github.com/Upstatement/editorial-wp-theme/pull/15

## How To Test

1. Run `./bin/uninstall` to destroy your current environment
2. Run `./bin/install` to re-build with an updated `wp-config.php`
3. Run `./bin/start` and confirm that you can access the site at `http://localhost:3000`, `http://skela.ups.dock` or `https://skela.ups.dock` without issues

