### PR TITLE
Use kebab instead of camel case

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ Read more details on [creating Gutenberg blocks using ACF](https://www.advancedc
 
    There is an example custom block under `src/Blocks/SampleACFBlock/ACFBlock.php`. This demonstrates creating a block using ACF functions that includes two fields.
 
-   > Note that in order to get this example to work, you need to create an ACF field group containing two fields, `some_headline` and `some_text`, and then have the field group displayed if the block is equal to ACF Block.
+   > Note that in order to get this example to work, you need to create an ACF field group containing two fields, `some_headline` and `some_text`, and then have the field group displayed if the block is equal to ACF Block. Be sure to keep your block name all lowercase. ACF drops all uppercase letters and your block might not appear as an option if the names are mismatched. 
 
 2. Create a new twig file to render the ACF fields.
 

--- a/README.md
+++ b/README.md
@@ -301,7 +301,7 @@ Read more details on [creating Gutenberg blocks using ACF](https://www.advancedc
     {
         return array(
             ...
-            'acf/acfBlock',
+            'acf/acf-block',
             ...
         );
     }

--- a/src/Blocks/SampleACFBlock/ACFBlock.php
+++ b/src/Blocks/SampleACFBlock/ACFBlock.php
@@ -29,7 +29,7 @@ class ACFBlock
         if (function_exists('acf_register_block_type')) {
             acf_register_block_type(
                 array(
-                    'name'            => 'acfBlock',
+                    'name'            => 'acf-block',
                     'title'           => __('ACF Block'),
                     'description'     => __('A custom block that incorporates ACF fields.'),
                     'render_callback' => array($this, 'renderACFBlock'),


### PR DESCRIPTION
When I followed the steps to create a new custom block type, I used a camel cased name and the generated acf-json file had an all lowercase name, causing the block to not appear as an option when writing a post. Kebab case seems to work better. 

## Changes
- Update README and `SampleACFBlock/ACFBlock.php` to use kebab cased name instead of camel case

## How To Test
- When the associated acf-json file is created for a new custom block, the name should be consistent to the one defined in the block code.

## TODOs:
- [x] Point out and explain on the README why camel case does not work. ~Does anyone know why Wordpress flattens the block name to all lowercase in the first place?~ https://www.advancedcustomfields.com/blog/best-practices-designing-custom-fields/