### PR TITLE
Add theme version to context for stylesheet caching

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -16,15 +16,15 @@ define('SKELA_SITE_NAME', get_bloginfo('name'));
 define('SKELA_THEME_VERSION', wp_get_theme()->get('Version'));
 
 /**
+ * Use Dotenv to set required environment variables and load .env file when present.
+ */
+Dotenv\Dotenv::create(__DIR__)->safeLoad();
+
+/**
  * Set up our global environment constant and load its config first
  * Default: production
  */
 define('WP_ENV', getenv('WP_ENV') ?: 'production');
-
-/**
- * Use Dotenv to set required environment variables and load .env file when present.
- */
-Dotenv\Dotenv::create(__DIR__)->safeLoad();
 
 $timber = new Timber\Timber();
 Timber::$dirname = array('templates');

--- a/src/Managers/ThemeManager.php
+++ b/src/Managers/ThemeManager.php
@@ -18,6 +18,9 @@ class ThemeManager
     public function __construct(array $managers)
     {
         $this->managers = $managers;
+
+        add_filter('timber/context', array($this, 'addWpEnvToContext'));
+        add_filter('timber/context', array($this, 'addThemeVersionToContext'));
         add_filter('timber/context', array($this, 'addIsHomeToContext'));
         add_filter('timber/context', array($this, 'addMenusToContext'));
         add_filter('timber/context', array($this, 'addACFOptionsToContext'));
@@ -79,6 +82,34 @@ class ThemeManager
 
         wp_enqueue_script('vendor', SKELA_THEME_URL . '/dist/vendor.js', array(), SKELA_THEME_VERSION, false);
         wp_enqueue_script('admin.js', SKELA_THEME_URL . '/dist/admin.js', array(), SKELA_THEME_VERSION, false);
+    }
+
+    /**
+     * Adds ability to check the environment in a twig file
+     *
+     * @param array $context Timber context
+     *
+     * @return array
+     */
+    public function addWpEnvToContext($context)
+    {
+        $context['wp_env'] = WP_ENV;
+
+        return $context;
+    }
+
+    /**
+     * Expose current theme version to Timber context
+     *
+     * @param array $context Timber context
+     *
+     * @return array
+     */
+    public function addThemeVersionToContext($context)
+    {
+        $context['theme_version'] = SKELA_THEME_VERSION;
+
+        return $context;
     }
 
     /**

--- a/templates/includes/head.twig
+++ b/templates/includes/head.twig
@@ -1,0 +1,8 @@
+<head>
+  <meta charset="utf-8" />
+  <meta content="width=device-width, initial-scale=1" name="viewport" />
+  <title>{% if wp_title %}{{ wp_title }} | {{ site.name }}{% else %}{{ site.name }}{% endif %}</title>
+  <link rel="stylesheet" href="{{ theme.link }}/dist/app.css?v={{ theme_version }}" type="text/css" media="all" />
+
+  {{ function('wp_head') }}
+</head>

--- a/templates/layouts/base.twig
+++ b/templates/layouts/base.twig
@@ -1,13 +1,7 @@
 <!DOCTYPE html>
 <html class="no-js" lang="en-us">
-<head>
-  <meta charset="utf-8" />
-  <meta content="width=device-width, initial-scale=1" name="viewport" />
-  <title>{% if wp_title %}{{ wp_title }} | {{ site.name }}{% else %}{{ site.name }}{% endif %}</title>
-  {{ function('wp_head') }}
 
-  <link rel="stylesheet" href="{{ theme.link }}/dist/app.css?v={{ css_last_modified }}" type="text/css" media="all" />
-</head>
+{% include "includes/head.twig" %}
 
 <body class="{{ body_class }}{% if pagename %} page-name-{{ pagename }}{% endif %}">
 
@@ -27,3 +21,5 @@
   {{ function('wp_footer') }}
 
 </body>
+
+</html>


### PR DESCRIPTION
## Changes

- Add `wp_env` and `theme_version` to context
- Add theme version to stylesheet
- Add closing HTML tag
- Move `<head>` contents to partial

## How To Test

Open up the site with the network tab open and make sure the version is appended to the stylesheet

![image](https://user-images.githubusercontent.com/6599979/89556448-662b1600-d7df-11ea-99dc-1980dd500849.png)
