### PR TITLE
Update php code style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,3 +14,4 @@ trim_trailing_whitespace = true
 # https://github.com/pixelandtonic/CodingStandards
 [*.php]
 indent_size = 4
+indent_style = space

--- a/.editorconfig
+++ b/.editorconfig
@@ -14,4 +14,4 @@ trim_trailing_whitespace = true
 # https://github.com/pixelandtonic/CodingStandards
 [*.php]
 indent_size = 4
-indent_style = space
+indent_style = tab

--- a/404.php
+++ b/404.php
@@ -2,6 +2,7 @@
 /**
  * Generic 404 page controller.
  *
+ * @package Skela
  */
 
 $context = Timber::context();
@@ -10,4 +11,4 @@ $context = Timber::context();
 $context['wp_title'] = '404 Not Found';
 
 // Render view.
-Timber::render('pages/404.twig', $context);
+Timber::render( 'pages/404.twig', $context );

--- a/composer.json
+++ b/composer.json
@@ -37,11 +37,14 @@
     "wpackagist-plugin/wp-environment-indicator": "^1.0",
     "vlucas/phpdotenv": "^3.3",
     "timber/timber": "^1.10",
-    "nesbot/carbon": "^2.19"
+    "nesbot/carbon": "^2.19",
+    "php-ds/php-ds": "^1.2"
   },
   "require-dev": {
     "squizlabs/php_codesniffer": "^3.4",
     "friendsofphp/php-cs-fixer": "^2.15",
-    "symfony/var-dumper": "^4.3"
+    "symfony/var-dumper": "^4.3",
+    "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
+    "wp-coding-standards/wpcs": "*"
   }
 }

--- a/front-page.php
+++ b/front-page.php
@@ -1,15 +1,17 @@
 <?php
 /**
  * Front page
-*/
+ *
+ * @package Skela
+ */
 
 use Skela\Repositories\PostTypeRepository;
 
 $context = Timber::context();
 
-$postTypeRepo = new PostTypeRepository();
-$latestPosts = $postTypeRepo->latestPosts(10, null, [], null)->get();
-$context['posts'] = $latestPosts;
+$post_repo = new PostTypeRepository();
+$latest_posts = $post_repo->latest_posts( 10, null, [], null )->get();
+$context['posts'] = $latest_posts;
 
 // Render view.
-Timber::render('pages/front-page.twig', $context);
+Timber::render( 'pages/front-page.twig', $context );

--- a/functions.php
+++ b/functions.php
@@ -2,48 +2,51 @@
 /**
  * WP Theme constants and setup functions
  *
- * @package ThemeSkela
+ * @package Skela
  */
 
+/**
+ * Require the autoloader.
+ */
 require_once 'vendor/autoload.php';
 
 use Skela\Managers\ThemeManager;
 
-define('SKELA_THEME_URL', get_stylesheet_directory_uri());
-define('SKELA_THEME_PATH', dirname(__FILE__) . '/');
-define('SKELA_DOMAIN', get_site_url());
-define('SKELA_SITE_NAME', get_bloginfo('name'));
-define('SKELA_THEME_VERSION', wp_get_theme()->get('Version'));
+define( 'SKELA_THEME_URL', get_stylesheet_directory_uri() );
+define( 'SKELA_THEME_PATH', dirname( __FILE__ ) . '/' );
+define( 'SKELA_DOMAIN', get_site_url() );
+define( 'SKELA_SITE_NAME', get_bloginfo( 'name' ) );
+define( 'SKELA_THEME_VERSION', wp_get_theme()->get( 'Version' ) );
 
 /**
  * Use Dotenv to set required environment variables and load .env file when present.
  */
-Dotenv\Dotenv::create(__DIR__)->safeLoad();
+Dotenv\Dotenv::create( __DIR__ )->safeLoad();
 
 /**
  * Set up our global environment constant and load its config first
  * Default: production
  */
-define('WP_ENV', getenv('WP_ENV') ?: 'production');
+define( 'WP_ENV', getenv( 'WP_ENV' ) ?: 'production' );
 
 $timber = new Timber\Timber();
-Timber::$dirname = array('templates');
+Timber::$dirname = array( 'templates' );
 
 add_action(
-    'after_setup_theme',
-    function () {
-        $managers = [
-            // new \Skela\Managers\TaxonomiesManager(),
-            new \Skela\Managers\WordPressManager(),
-            new \Skela\Managers\GutenbergManager(),
-            new \Skela\Managers\CustomPostsManager(),
-        ];
+	'after_setup_theme',
+	function () {
+		$managers = [
+			/* new \Skela\Managers\TaxonomiesManager(), */
+			new \Skela\Managers\WordPressManager(),
+			new \Skela\Managers\GutenbergManager(),
+			new \Skela\Managers\CustomPostsManager(),
+		];
 
-        if (function_exists('acf_add_local_field_group')) {
-            $managers[] = new \Skela\Managers\ACFManager();
-        }
+		if ( function_exists( 'acf_add_local_field_group' ) ) {
+			$managers[] = new \Skela\Managers\ACFManager();
+		}
 
-        $themeManager = new ThemeManager($managers);
-        $themeManager->run();
-    }
+		$theme_manager = new ThemeManager( $managers );
+		$theme_manager->run();
+	}
 );

--- a/index.php
+++ b/index.php
@@ -1,12 +1,14 @@
 <?php
 /**
- * Based on WP's template hierarchy, we are setting the home page to use the front-page.php file.
- * index.php is the last fallback file that is used in the hierarchy and as such we should issue
- * a 404 response if WP ever gets here.
+ * Based on WP's template hierarchy, we are setting the home page to use the
+ * `front-page.php` file. `index.php` is the last fallback file that is used in the
+ * hierarchy and as such we should issue a 404 response if WP ever gets here.
  *
+ * @package Skela
  */
-if (!defined('ABSPATH')) {
-    die('Direct access forbidden.');
+
+if ( ! defined( 'ABSPATH' ) ) {
+	die( 'Direct access forbidden.' );
 }
 
-\Skela\Services\WordPressService::abort_request(404);
+\Skela\Services\WordPressService::abort_request( 404 );

--- a/page.php
+++ b/page.php
@@ -1,11 +1,14 @@
 <?php
 /**
- * Page
+ * Page.
+ *
+ * @package Skela
  */
 
 $context = Timber::context();
 
 $page = Timber::get_post();
+
 $context['page'] = $page;
 
-Timber::render('pages/page.twig', $context);
+Timber::render( 'pages/page.twig', $context );

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -9,21 +9,65 @@
   <exclude-pattern>*.css</exclude-pattern>
 
   <!-- Don't hide tokenizer exceptions -->
-    <rule ref="Internal.Tokenizer.Exception">
-        <type>error</type>
-    </rule>
+  <rule ref="Internal.Tokenizer.Exception">
+    <type>error</type>
+  </rule>
 
-    <!-- Include the whole PEAR standard -->
-    <rule ref="PEAR">
-        <exclude name="PEAR.NamingConventions.ValidFunctionName" />
-        <exclude name="PEAR.NamingConventions.ValidVariableName" />
-        <exclude name="PEAR.Commenting.ClassComment" />
-        <exclude name="PEAR.Commenting.FileComment" />
-        <exclude name="PEAR.Commenting.InlineComment" />
-        <exclude name="PEAR.WhiteSpace.ScopeIndent" />
-    </rule>
+  <!-- Include the WordPress-Extra standard. -->
+  <rule ref="WordPress-Extra">
+    <!--
+    We may want a middle ground though. The best way to do this is add the
+    entire ruleset, then rule by rule, remove ones that don't suit a project.
+    We can do this by running `phpcs` with the '-s' flag, which allows us to
+    see the names of the sniffs reporting errors.
+    Once we know the sniff names, we can opt to exclude sniffs which don't
+    suit our project like so.
+    The below two examples just show how you can exclude rules.
+    They are not intended as advice about which sniffs to exclude.
+    -->
 
+    <!--
+    <exclude name="WordPress.WhiteSpace.ControlStructureSpacing"/>
+    <exclude name="WordPress.Security.EscapeOutput"/>
+    -->
+  </rule>
 
+  <!-- Let's also check that everything is properly documented. -->
+  <rule ref="WordPress-Docs"/>
 
+  <!-- Add in some extra rules from other standards. -->
+  <rule ref="Generic.CodeAnalysis.UnusedFunctionParameter"/>
+  <rule ref="Generic.Commenting.Todo"/>
+
+  <config name="minimum_supported_wp_version" value="5.0"/>
+
+  <!-- Text domains -->
+  <!-- <rule ref="WordPress.WP.I18n">
+    <properties>
+      <property name="text_domain" type="array">
+        <element value="my-textdomain"/>
+        <element value="library-textdomain"/>
+      </property>
+    </properties>
+  </rule> -->
+
+  <rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+    <exclude name="WordPress.NamingConventions.PrefixAllGlobals" />
+  </rule>
+
+  <rule ref="Generic.Files.LineLength">
+    <properties>
+      <property name="lineLimit" value="85"/>
+      <property name="absoluteLineLimit" value="0"/>
+    </properties>
+  </rule>
+
+  <!-- Add some custom exclusions to filename rules to enable proper namespacing. -->
+  <rule ref="WordPress.Files.FileName">
+    <properties>
+      <property name="strict_class_file_names" value="false"/>
+    </properties>
+    <exclude name="WordPress.Files.FileName.NotHyphenatedLowercase" />
+  </rule>
 
 </ruleset>

--- a/single.php
+++ b/single.php
@@ -1,11 +1,14 @@
 <?php
 /**
- * Single post / article
+ * Single post / article.
+ *
+ * @package Skela
  */
 
 $context = Timber::context();
 
 $post = Timber::get_post();
+
 $context['article'] = $post;
 
-Timber::render('pages/article.twig', $context);
+Timber::render( 'pages/article.twig', $context );

--- a/src/Blocks/Blocks.php
+++ b/src/Blocks/Blocks.php
@@ -1,46 +1,47 @@
 <?php
 /**
- * Blocks Initializer
+ * Blocks Initializer. Enqueue CSS/JS of all the blocks.
  *
- * Enqueue CSS/JS of all the blocks.
+ * @package Skela
  */
+
 namespace Skela\Blocks;
 
-class Blocks
-{
-    /**
-     * Enqueue assets needed for block
-     */
-    public function __construct()
-    {
-        add_action('enqueue_block_editor_assets', array($this,'enqueueBlockEditorAssets'));
+/** Class */
+class Blocks {
 
-        new SampleACFBlock\ACFBlock();
-        new RelatedArticles\RelatedArticles();
-        new ImageLayout\ImageLayout();
+	/**
+	 * Enqueue assets needed for block
+	 */
+	public function __construct() {
+		add_action( 'enqueue_block_editor_assets', array( $this, 'enqueue_editor_assets' ) );
 
-    }
+		new SampleACFBlock\ACFBlock();
+		new RelatedArticles\RelatedArticles();
+		new ImageLayout\ImageLayout();
 
-    /**
-     * Enqueue Gutenberg block assets for backend editor.
-     *
-     * @return null
-     */
-    public function enqueueBlockEditorAssets()
-    {
-        // Scripts.
-        wp_enqueue_script(
-            'block-js', // Handle.
-            SKELA_THEME_URL . '/dist/blocks.js', // Block.block.js: We register the block here. Built with Webpack.
-            array('wp-blocks', 'wp-i18n', 'wp-element', 'manifest', 'vendor', 'wp-editor'), // Dependencies, defined above.
-            true // Enqueue the script in the footer.
-        );
+	}
 
-        // Styles.
-        wp_enqueue_style(
-            'block-editor-css', // Handle.
-            SKELA_THEME_URL . '/dist/blocks.css', // Block editor CSS.
-            array('wp-edit-blocks') // Dependency to include the CSS after it.
-        );
-    }
+	/**
+	 * Enqueue Gutenberg block assets for backend editor.
+	 *
+	 * @return void
+	 */
+	public function enqueue_editor_assets() {
+		// Scripts.
+		wp_enqueue_script(
+			'block-js', // Handle.
+			SKELA_THEME_URL . '/dist/blocks.js', // Block.block.js: We register the block here. Built with Webpack.
+			array( 'wp-blocks', 'wp-i18n', 'wp-element', 'manifest', 'vendor', 'wp-editor' ), // Dependencies, defined above.
+			true // Enqueue the script in the footer.
+		);
+
+		// Styles.
+		wp_enqueue_style(
+			'block-editor-css', // Handle.
+			SKELA_THEME_URL . '/dist/blocks.css', // Block editor CSS.
+			array( 'wp-edit-blocks' ), // Dependency to include the CSS after it.
+			SKELA_THEME_VERSION
+		);
+	}
 }

--- a/src/Blocks/ImageLayout/ImageLayout.php
+++ b/src/Blocks/ImageLayout/ImageLayout.php
@@ -10,7 +10,9 @@
  *     - 3-symmetrical : 3 Symmetrical
  *     - 3-asymmetrical : 3 Asymmetrical
  * - imageLayoutCrop (True / False)
- * Set this field group if the block is equal to Image Layout
+ * Set this field group if the block is equal to Image Layout.
+ *
+ * @package Skela
  */
 
 namespace Skela\Blocks\ImageLayout;
@@ -18,69 +20,64 @@ namespace Skela\Blocks\ImageLayout;
 use Timber\Timber;
 use Timber\PostQuery;
 
+/** Class */
+class ImageLayout {
 
-class ImageLayout
-{
-    /**
-     * Constructor
-     */
-    public function __construct()
-    {
-        add_action('acf/init', array($this,'createImageLayout'));
-    }
+	/**
+	 * Constructor
+	 */
+	public function __construct() {
+		add_action( 'acf/init', array( $this, 'register' ) );
+	}
 
-    /**
-     * Uses ACF function to register custom blocks
-     *
-     * @return void
-     */
-    public function createImageLayout()
-    {
-        if (function_exists('acf_register_block')) {
-            acf_register_block_type(
-                array(
-                    'name'              => 'imageLayout',
-                    'title'             => __('Image Layout'),
-                    'description'       => __('A custom image block.'),
-                    'render_callback'   => array($this, 'renderImageLayout'),
-                    'category'          => 'formatting',
-                    'icon'              => 'images-alt',
-                    'keywords'          => array('image', 'layout'),
-                    'mode'              => 'edit'
-                )
-            );
-        }
-    }
+	/**
+	 * Uses ACF function to register custom blocks.
+	 *
+	 * @return void
+	 */
+	public function register() {
+		if ( function_exists( 'acf_register_block' ) ) {
+			acf_register_block_type(
+				array(
+					'name'            => 'imageLayout',
+					'title'           => __( 'Image Layout' ),
+					'description'     => __( 'A custom image block.' ),
+					'render_callback' => array( $this, 'render' ),
+					'category'        => 'formatting',
+					'icon'            => 'images-alt',
+					'keywords'        => array( 'image', 'layout' ),
+					'mode'            => 'edit',
+				)
+			);
+		}
+	}
 
-    /**
-     * Get info from the related ACF fields
-     * and then render corrosponding template
-     *
-     * @param array  $block      The block settings and attributes.
-     * @param string $content    The block content (empty content).
-     * @param bool   $is_preview True during AJAX preview.
-     *
-     * @return void
-     */
-    public function renderImageLayout($block, $content, $is_preview)
-    {
-        $context['layout'] = get_field('imageLayoutLayout');
-        $context['cropToSameRatio'] = get_field('imageLayoutCrop');
+	/**
+	 * Get info from the related ACF fields and then render corrosponding template.
+	 *
+	 * @param array  $block      The block settings and attributes.
+	 * @param string $content    The block content (empty content).
+	 * @param bool   $is_preview True during AJAX preview.
+	 *
+	 * @return void
+	 */
+	public function render( $block, $content, $is_preview ) {
+		$context['layout']          = get_field( 'imageLayoutLayout' );
+		$context['cropToSameRatio'] = get_field( 'imageLayoutCrop' );
 
+		$context['images'] = array_map(
+			function ( $image ) {
+				return new \TimberImage( $image['id'] );
+			},
+			get_field( 'imageLayoutImages' )
+		);
 
-        $context['images'] = array_map(
-            function ($image) {
-                return new \TimberImage($image['id']);
-            },
-            get_field('imageLayoutImages')
-        );
+		$templates = array( 'templates/components/image-layout.twig' );
 
-        $templates = ['templates/components/image-layout.twig' ];
-
-        if ($is_preview) {
-            echo "Preview mode is not supported for related articles. Please change to Edit mode by clicking the pencil icon in the toolbar above.";
-        } else {
-            Timber::render($templates, $context);
-        }
-    }
+		if ( $is_preview ) {
+			echo 'Preview mode is not supported for related articles. Please change to Edit mode by clicking the pencil icon in the toolbar above.';
+		} else {
+			Timber::render( $templates, $context );
+		}
+	}
 }

--- a/src/Blocks/RelatedArticles/RelatedArticles.php
+++ b/src/Blocks/RelatedArticles/RelatedArticles.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * Custom block for inserting a list of Related articles
  *
@@ -7,92 +6,98 @@
  * - header_text (Text)
  * - chosen_articles (Repeater) with the following sub field:
  *     - related_article (Post Object)
- * Set this field group if the block is equal to Related Articles
+ * Set this field group if the block is equal to Related Articles.
+ *
+ * @package Skela
  */
+
 namespace Skela\Blocks\RelatedArticles;
 
 use Timber\Timber;
 use Timber\PostQuery;
 
-class RelatedArticles
-{
-    /**
-     * Constructor
-     */
-    public function __construct()
-    {
-                add_action('acf/init', array($this,'createRelatedArticlesBlock'));
-    }
+/** Class */
+class RelatedArticles {
 
-    /**
-     * Uses ACF function to register custom blocks
-     *
-     * @return void
-     */
-    public function createRelatedArticlesBlock()
-    {
-        // check function exists
-        if (function_exists('acf_register_block')) {
+	/**
+	 * Constructor
+	 */
+	public function __construct() {
+		add_action( 'acf/init', array( $this, 'register' ) );
+	}
 
-        // register RelatedArticles block
-            acf_register_block(
-                array(
-                    'name'            => 'relatedArticles',
-                    'title'           => __('Related Articles'),
-                    'description'     => __('A custom block for inserting links to other articles.'),
-                    'render_callback' => array($this, 'renderRelatedArticlesBlock'),
-                    'category'        => 'widgets',
-                    'icon'            => array('background' => '#ecf6f6', 'src' => 'list-view'),
-                    'keywords'        => array('related', 'articles'),
-                    'mode'            => 'edit'
-                )
-            );
-        }
-    }
+	/**
+	 * Uses ACF function to register custom blocks
+	 *
+	 * @return void
+	 */
+	public function register() {
+		// Check that ACF exists.
+		if ( function_exists( 'acf_register_block' ) ) {
 
-    /**
-     * Get the Related Articles text and related articles,
-     * and then render corrosponding template
-     *
-     * @param array  $block      The block settings and attributes.
-     * @param string $content    The block content (empty content).
-     * @param bool   $is_preview True during AJAX preview.
-     *
-     * @return void
-     */
-    public function renderRelatedArticlesBlock($block, $content, $is_preview)
-    {
-        $context = Timber::context();
-        $context['relatedArticlesHeader'] = get_field('header_text');
-        $relatedArticles = get_field('chosen_articles');
-        $relatedArticlesIDs = [];
+			// Register the block.
+			acf_register_block(
+				array(
+					'name'            => 'relatedArticles',
+					'title'           => __( 'Related Articles' ),
+					'description'     => __( 'A custom block for inserting links to other articles.' ),
+					'render_callback' => array( $this, 'render' ),
+					'category'        => 'widgets',
+					'icon'            => array(
+						'background' => '#ecf6f6',
+						'src' => 'list-view',
+					),
+					'keywords'        => array( 'related', 'articles' ),
+					'mode'            => 'edit',
+				)
+			);
+		}
+	}
 
-        if (!empty($relatedArticles)) {
-            if (is_array($relatedArticles) && sizeof($relatedArticles) > 0) {
-                foreach ($relatedArticles as $article) {
-                    if (!empty($article['related_article'])) {
+	/**
+	 * Get the Related Articles text and related articles,
+	 * and then render corrosponding template
+	 *
+	 * @param array  $block      The block settings and attributes.
+	 * @param string $content    The block content (empty content).
+	 * @param bool   $is_preview True during AJAX preview.
+	 *
+	 * @return void
+	 */
+	public function render( $block, $content, $is_preview ) {
+		$context = Timber::context();
 
-                        $relatedArticlesIDs[] = $article['related_article']->ID;
-                    }
-                }
-                // Set query args
-                if (!empty($relatedArticlesIDs)) {
-                    $args = array(
-                        'post_status' => 'publish',
-                        'post__in' => $relatedArticlesIDs,
-                        'orderby' => 'post__in'
-                    );
+		$related_articles    = get_field( 'chosen_articles' );
+		$related_article_ids = array();
 
-                    $context['relatedArticles'] = new PostQuery($args);
+		$context['relatedArticlesHeader'] = get_field( 'header_text' );
 
-                }
-            }
-        }
+		if ( ! empty( $related_articles ) ) {
+			if ( is_array( $related_articles ) && count( $related_articles ) > 0 ) {
+				foreach ( $related_articles as $article ) {
+					if ( ! empty( $article['related_article'] ) ) {
 
-        if ($is_preview) {
-            echo "Preview mode is not supported for related articles. Please change to Edit mode by clicking the pencil icon in the toolbar above.";
-        } else {
-            Timber::render('templates/components/related-articles.twig', $context);
-        }
-    }
+						$related_article_ids[] = $article['related_article']->ID;
+					}
+				}
+
+				// Set query args.
+				if ( ! empty( $related_article_ids ) ) {
+					$args = array(
+						'post_status' => 'publish',
+						'post__in'    => $related_article_ids,
+						'orderby'     => 'post__in',
+					);
+
+					$context['relatedArticles'] = new PostQuery( $args );
+				}
+			}
+		}
+
+		if ( $is_preview ) {
+			echo 'Preview mode is not supported for related articles. Please change to Edit mode by clicking the pencil icon in the toolbar above.';
+		} else {
+			Timber::render( 'templates/components/related-articles.twig', $context );
+		}
+	}
 }

--- a/src/Blocks/SampleACFBlock/ACFBlock.php
+++ b/src/Blocks/SampleACFBlock/ACFBlock.php
@@ -2,63 +2,69 @@
 /**
  * Example for creating custom block that uses ACF fields
  *
- * In order to have this example work, you first have to create
- * a new custom field block with two ACF fields named some_headline and some_text,
- * and show the field group if the block is equal to ACF Block
+ * In order to have this example work, you first have to create a new custom field
+ * block with two ACF fields named some_headline and some_text, and show the field
+ * group if the block is equal to ACF Block.
+ *
+ * @package Skela
  */
+
 namespace Skela\Blocks\SampleACFBlock;
 
 use Timber\Timber;
 
-class ACFBlock
-{
-    /**
-     * Constructor
-     */
-    public function __construct()
-    {
-        add_action('acf/init', array($this,'createACFBlock'));
-    }
-    /**
-     * Uses ACF function to register custom blocks
-     *
-     * @return void
-     */
-    public function createACFBlock()
-    {
-        if (function_exists('acf_register_block_type')) {
-            acf_register_block_type(
-                array(
-                    'name'            => 'acf-block',
-                    'title'           => __('ACF Block'),
-                    'description'     => __('A custom block that incorporates ACF fields.'),
-                    'render_callback' => array($this, 'renderACFBlock'),
-                    'category'        => 'widgets',
-                    'icon'            => array('background' => '#ecf6f6', 'src' => 'email'),
-                    'keywords'        => array('example', 'acf'),
-                    'mode'            => 'edit'
-                )
-            );
-        }
-    }
-    /**
-     * Get info from the related ACF fields
-     * and then render corrosponding template
-     *
-     * @param array  $block      The block settings and attributes.
-     * @param string $content    The block content (empty content).
-     * @param bool   $is_preview True during AJAX preview.
-     *
-     * @return void
-     */
-    public function renderACFBlock($block, $content, $is_preview)
-    {
-        // If the block renders info from TimberTheme, TimberSite, etc., then uncomment the following:
-        // $context = Timber::context();
+/** Class */
+class ACFBlock {
 
-        $context['some_headline'] = get_field('some_headline');
-        $context['some_text'] = get_field('some_text');
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		add_action( 'acf/init', array( $this, 'register' ) );
+	}
+	/**
+	 * Uses ACF function to register custom blocks
+	 *
+	 * @return void
+	 */
+	public function register() {
+		if ( function_exists( 'acf_register_block_type' ) ) {
+			acf_register_block_type(
+				array(
+					'name'            => 'acf-block',
+					'title'           => __( 'ACF Block' ),
+					'description'     => __( 'A custom block that incorporates ACF fields.' ),
+					'render_callback' => array( $this, 'render' ),
+					'category'        => 'widgets',
+					'icon'            => array(
+						'background' => '#ecf6f6',
+						'src'        => 'email',
+					),
+					'keywords'        => array( 'example', 'acf' ),
+					'mode'            => 'edit',
+				)
+			);
+		}
+	}
 
-        Timber::render(['templates/components/acf-block.twig'], $context);
-    }
+	/**
+	 * Get info from the related ACF fields
+	 * and then render corrosponding template
+	 *
+	 * @param array  $block      The block settings and attributes.
+	 * @param string $content    The block content (empty content).
+	 * @param bool   $is_preview True during AJAX preview.
+	 *
+	 * @return void
+	 */
+	public function render( $block, $content, $is_preview ) {
+		// If the block renders info from TimberTheme, TimberSite, etc., then
+		// uncomment the following.
+		/** $context = Timber::context(); */
+
+		$context['some_headline'] = get_field( 'some_headline' );
+		$context['some_text']     = get_field( 'some_text' );
+
+		Timber::render( array( 'templates/components/acf-block.twig' ), $context );
+	}
 }

--- a/src/Managers/ACFManager.php
+++ b/src/Managers/ACFManager.php
@@ -5,223 +5,223 @@
  * those to appear in the admin panel.
  *
  * This file should only be called if ACF is enabled.
+ *
+ * @package Skela
  */
+
 namespace Skela\Managers;
 
-class ACFManager
-{
+/** Class */
+class ACFManager {
 
-    /**
-     * Runs initialization tasks.
-     *
-     * @return void
-     */
-    public function run()
-    {
-        add_action('init', [$this, 'imageLayoutFields'], 1);
-        add_action('init', [$this, 'relatedArticleFields'], 1);
-    }
+	/**
+	 * Runs initialization tasks.
+	 *
+	 * @return void
+	 */
+	public function run() {
+		add_action( 'init', array( $this, 'image_layout_fields' ), 1 );
+		add_action( 'init', array( $this, 'related_article_fields' ), 1 );
+	}
 
 
-    /**
-     * Register image layout fields
-     *
-     * @return void
-     */
-    public function imageLayoutFields()
-    {
-        acf_add_local_field_group(
-            array(
-            'key' => 'group_5cdef47b943c9',
-            'title' => 'Image Layout',
-            'fields' => array(
-                array(
-                    'key' => 'field_5cdef487a8fcc',
-                    'label' => 'Images',
-                    'name' => 'imageLayoutImages',
-                    'type' => 'gallery',
-                    'instructions' => '',
-                    'required' => 0,
-                    'conditional_logic' => 0,
-                    'wrapper' => array(
-                        'width' => '',
-                        'class' => '',
-                        'id' => '',
-                    ),
-                    'min' => '2',
-                    'max' => '3',
-                    'insert' => 'append',
-                    'library' => 'all',
-                    'min_width' => '',
-                    'min_height' => '',
-                    'min_size' => '',
-                    'max_width' => '',
-                    'max_height' => '',
-                    'max_size' => '',
-                    'mime_types' => '',
-                    'return_format' => 'array',
-                    'preview_size' => 'medium',
-                ),
-                array(
-                    'key' => 'field_5cdef49aa8fcd',
-                    'label' => 'Layout',
-                    'name' => 'imageLayoutLayout',
-                    'type' => 'radio',
-                    'instructions' => '',
-                    'required' => 0,
-                    'conditional_logic' => 0,
-                    'wrapper' => array(
-                        'width' => '',
-                        'class' => '',
-                        'id' => '',
-                    ),
-                    'choices' => array(
-                        '2-symmetrical' => '2 Symmetrical',
-                        '2-asymmetrical' => '2 Asymmetrical',
-                        '3-symmetrical' => '3 Symmetrical',
-                        '3-asymmetrical' => '3 Asymmetrical',
-                    ),
-                    'allow_null' => 0,
-                    'other_choice' => 0,
-                    'default_value' => '',
-                    'layout' => 'horizontal',
-                    'return_format' => 'value',
-                    'save_other_choice' => 0,
-                ),
-                array(
-                    'key' => 'field_5cdeffb837320',
-                    'label' => 'Crop image to same aspect ratio?',
-                    'name' => 'imageLayoutCrop',
-                    'type' => 'true_false',
-                    'instructions' => '',
-                    'required' => 0,
-                    'conditional_logic' => 0,
-                    'wrapper' => array(
-                        'width' => '',
-                        'class' => '',
-                        'id' => '',
-                    ),
-                    'message' => '',
-                    'default_value' => 0,
-                    'ui' => 1,
-                    'ui_on_text' => '',
-                    'ui_off_text' => '',
-                ),
-            ),
-            'location' => array(
-                array(
-                    array(
-                        'param' => 'block',
-                        'operator' => '==',
-                        'value' => 'acf/imagelayout',
-                    ),
-                ),
-            ),
-            'menu_order' => 0,
-            'position' => 'normal',
-            'style' => 'default',
-            'label_placement' => 'top',
-            'instruction_placement' => 'label',
-            'hide_on_screen' => '',
-            'active' => true,
-            'description' => '',
-            )
-        );
-    }
+	/**
+	 * Register image layout fields
+	 *
+	 * @return void
+	 */
+	public function image_layout_fields() {
+		acf_add_local_field_group(
+			array(
+				'key'                   => 'group_5cdef47b943c9',
+				'title'                 => 'Image Layout',
+				'fields'                => array(
+					array(
+						'key'               => 'field_5cdef487a8fcc',
+						'label'             => 'Images',
+						'name'              => 'imageLayoutImages',
+						'type'              => 'gallery',
+						'instructions'      => '',
+						'required'          => 0,
+						'conditional_logic' => 0,
+						'wrapper'           => array(
+							'width' => '',
+							'class' => '',
+							'id'    => '',
+						),
+						'min'               => '2',
+						'max'               => '3',
+						'insert'            => 'append',
+						'library'           => 'all',
+						'min_width'         => '',
+						'min_height'        => '',
+						'min_size'          => '',
+						'max_width'         => '',
+						'max_height'        => '',
+						'max_size'          => '',
+						'mime_types'        => '',
+						'return_format'     => 'array',
+						'preview_size'      => 'medium',
+					),
+					array(
+						'key'               => 'field_5cdef49aa8fcd',
+						'label'             => 'Layout',
+						'name'              => 'imageLayoutLayout',
+						'type'              => 'radio',
+						'instructions'      => '',
+						'required'          => 0,
+						'conditional_logic' => 0,
+						'wrapper'           => array(
+							'width' => '',
+							'class' => '',
+							'id'    => '',
+						),
+						'choices'           => array(
+							'2-symmetrical'  => '2 Symmetrical',
+							'2-asymmetrical' => '2 Asymmetrical',
+							'3-symmetrical'  => '3 Symmetrical',
+							'3-asymmetrical' => '3 Asymmetrical',
+						),
+						'allow_null'        => 0,
+						'other_choice'      => 0,
+						'default_value'     => '',
+						'layout'            => 'horizontal',
+						'return_format'     => 'value',
+						'save_other_choice' => 0,
+					),
+					array(
+						'key'               => 'field_5cdeffb837320',
+						'label'             => 'Crop image to same aspect ratio?',
+						'name'              => 'imageLayoutCrop',
+						'type'              => 'true_false',
+						'instructions'      => '',
+						'required'          => 0,
+						'conditional_logic' => 0,
+						'wrapper'           => array(
+							'width' => '',
+							'class' => '',
+							'id'    => '',
+						),
+						'message'           => '',
+						'default_value'     => 0,
+						'ui'                => 1,
+						'ui_on_text'        => '',
+						'ui_off_text'       => '',
+					),
+				),
+				'location'              => array(
+					array(
+						array(
+							'param'    => 'block',
+							'operator' => '==',
+							'value'    => 'acf/imagelayout',
+						),
+					),
+				),
+				'menu_order'            => 0,
+				'position'              => 'normal',
+				'style'                 => 'default',
+				'label_placement'       => 'top',
+				'instruction_placement' => 'label',
+				'hide_on_screen'        => '',
+				'active'                => true,
+				'description'           => '',
+			)
+		);
+	}
 
-    /**
-     * Register related article fields
-     *
-     * @return void
-     */
-    public function relatedArticleFields()
-    {
-        acf_add_local_field_group(
-            array(
-            'key' => 'group_5cd5a5077e357',
-            'title' => 'Related Articles',
-            'fields' => array(
-                array(
-                    'key' => 'field_5cd5a5401a9eb',
-                    'label' => 'Header text',
-                    'name' => 'header_text',
-                    'type' => 'text',
-                    'instructions' => '',
-                    'required' => 0,
-                    'conditional_logic' => 0,
-                    'wrapper' => array(
-                        'width' => '',
-                        'class' => '',
-                        'id' => '',
-                    ),
-                    'default_value' => 'Related Articles',
-                    'placeholder' => '',
-                    'prepend' => '',
-                    'append' => '',
-                    'maxlength' => '',
-                ),
-                array(
-                    'key' => 'field_5cd5a50d1a9e9',
-                    'label' => 'Chosen articles',
-                    'name' => 'chosen_articles',
-                    'type' => 'repeater',
-                    'instructions' => '',
-                    'required' => 1,
-                    'conditional_logic' => 0,
-                    'wrapper' => array(
-                        'width' => '',
-                        'class' => '',
-                        'id' => '',
-                    ),
-                    'collapsed' => '',
-                    'min' => 1,
-                    'max' => 4,
-                    'layout' => 'table',
-                    'button_label' => 'Add an article',
-                    'sub_fields' => array(
-                        array(
-                            'key' => 'field_5cd5c5733d782',
-                            'label' => 'Related Article',
-                            'name' => 'related_article',
-                            'type' => 'post_object',
-                            'instructions' => '',
-                            'required' => 0,
-                            'conditional_logic' => 0,
-                            'wrapper' => array(
-                                'width' => '',
-                                'class' => '',
-                                'id' => '',
-                            ),
-                            'post_type' => array(
-                                0 => 'post',
-                            ),
-                            'taxonomy' => '',
-                            'allow_null' => 0,
-                            'multiple' => 0,
-                            'return_format' => 'object',
-                            'ui' => 1,
-                        ),
-                    ),
-                ),
-            ),
-            'location' => array(
-                array(
-                    array(
-                        'param' => 'block',
-                        'operator' => '==',
-                        'value' => 'acf/relatedarticles',
-                    ),
-                ),
-            ),
-            'menu_order' => 0,
-            'position' => 'normal',
-            'style' => 'default',
-            'label_placement' => 'top',
-            'instruction_placement' => 'label',
-            'hide_on_screen' => '',
-            'active' => true,
-            'description' => '',
-            )
-        );
-    }
+	/**
+	 * Register related article fields
+	 *
+	 * @return void
+	 */
+	public function related_article_fields() {
+		acf_add_local_field_group(
+			array(
+				'key'                   => 'group_5cd5a5077e357',
+				'title'                 => 'Related Articles',
+				'fields'                => array(
+					array(
+						'key'               => 'field_5cd5a5401a9eb',
+						'label'             => 'Header text',
+						'name'              => 'header_text',
+						'type'              => 'text',
+						'instructions'      => '',
+						'required'          => 0,
+						'conditional_logic' => 0,
+						'wrapper'           => array(
+							'width' => '',
+							'class' => '',
+							'id'    => '',
+						),
+						'default_value'     => 'Related Articles',
+						'placeholder'       => '',
+						'prepend'           => '',
+						'append'            => '',
+						'maxlength'         => '',
+					),
+					array(
+						'key'               => 'field_5cd5a50d1a9e9',
+						'label'             => 'Chosen articles',
+						'name'              => 'chosen_articles',
+						'type'              => 'repeater',
+						'instructions'      => '',
+						'required'          => 1,
+						'conditional_logic' => 0,
+						'wrapper'           => array(
+							'width' => '',
+							'class' => '',
+							'id'    => '',
+						),
+						'collapsed'         => '',
+						'min'               => 1,
+						'max'               => 4,
+						'layout'            => 'table',
+						'button_label'      => 'Add an article',
+						'sub_fields'        => array(
+							array(
+								'key'               => 'field_5cd5c5733d782',
+								'label'             => 'Related Article',
+								'name'              => 'related_article',
+								'type'              => 'post_object',
+								'instructions'      => '',
+								'required'          => 0,
+								'conditional_logic' => 0,
+								'wrapper'           => array(
+									'width' => '',
+									'class' => '',
+									'id'    => '',
+								),
+								'post_type'         => array(
+									0 => 'post',
+								),
+								'taxonomy'          => '',
+								'allow_null'        => 0,
+								'multiple'          => 0,
+								'return_format'     => 'object',
+								'ui'                => 1,
+							),
+						),
+					),
+				),
+				'location'              => array(
+					array(
+						array(
+							'param'    => 'block',
+							'operator' => '==',
+							'value'    => 'acf/relatedarticles',
+						),
+					),
+				),
+				'menu_order'            => 0,
+				'position'              => 'normal',
+				'style'                 => 'default',
+				'label_placement'       => 'top',
+				'instruction_placement' => 'label',
+				'hide_on_screen'        => '',
+				'active'                => true,
+				'description'           => '',
+			)
+		);
+	}
 }

--- a/src/Managers/CustomPostsManager.php
+++ b/src/Managers/CustomPostsManager.php
@@ -1,45 +1,54 @@
 <?php
 /**
  * Bootstraps settings and configurations for custom post types.
+ *
+ * @package Skela
  */
+
 namespace Skela\Managers;
 
-class CustomPostsManager
-{
+/** Class */
+class CustomPostsManager {
 
-    /**
-     * Runs initialization tasks.
-     *
-     * @return void
-     */
-    public function run()
-    {
-        add_action('init', [$this, 'registerPostTypes'], 1);
-    }
+	/**
+	 * Runs initialization tasks.
+	 *
+	 * @return void
+	 */
+	public function run() {
+		add_action( 'init', array( $this, 'register_post_types' ), 1 );
+	}
 
 
-    /**
-     * Register post types in WoPostsrdPress
-     *
-     * @return void
-     */
-    public function registerPostTypes()
-    {
+	/**
+	 * Register post types in WoPostsrdPress
+	 *
+	 * @return void
+	 */
+	public function register_post_types() {
+		/*
+		// This is an example of the `register_post_type` call. Note that you should
+		// *not* register an "author" post type since that is a reserved type in
+		// WordPress. This code is here for referene only.
+		// Author post type.
+		$author_labels = array(
+			'name'          => __( 'Authors' ),
+			'singular_name' => __( 'Author' ),
+			'add_new_item'  => __( 'Add New Author' ),
+		);
 
-        // Author post type
-        $authorLabels = ['name' => __('Authors'),
-                     'singular_name' => __('Author'),
-                     'add_new_item' => __('Add New Author')];
-
-        register_post_type(
-            'author',
-            ['labels' => $authorLabels,
-            'public' => true,
-            'has_archive' => true,
-            'menu_position' => 5,
-            'rewrite' => ['slug' => 'authors'],
-            'supports' => ['editor', 'excerpt', 'title', 'thumbnail'],
-            'taxonomies' => []]
-        );
-    }
+		register_post_type(
+			'author',
+			array(
+				'labels'        => $author_labels,
+				'public'        => true,
+				'has_archive'   => true,
+				'menu_position' => 5,
+				'rewrite'       => array( 'slug' => 'authors' ),
+				'supports'      => array( 'editor', 'excerpt', 'title', 'thumbnail' ),
+				'taxonomies'    => array(),
+			)
+		);
+		*/
+	}
 }

--- a/src/Managers/GutenbergManager.php
+++ b/src/Managers/GutenbergManager.php
@@ -1,67 +1,68 @@
 <?php
 /**
- * Sets up Gutenberg and calls constructor for custom blocks
+ * Sets up Gutenberg and calls constructor for custom blocks.
+ *
+ * @package Skela
  */
+
 namespace Skela\Managers;
 
 use Skela\Blocks;
 
-class GutenbergManager
-{
+/** Class */
+class GutenbergManager {
 
-    /**
-     * Runs initialization tasks.
-     *
-     * @return void
-     */
-    public function run()
-    {
-        // TODO: Uncomment this to only allow certain blocks
-        // add_filter('allowed_block_types', array($this,'allowBlocks'));
+	/**
+	 * Runs initialization tasks.
+	 *
+	 * @return void
+	 */
+	public function run() {
+		// TODO: Uncomment this to only allow certain blocks.
+		/* add_filter( 'allowed_block_types', array( $this, 'allow_blocks' ) ); */
 
-        new \Skela\Blocks\Blocks();
-    }
+		new \Skela\Blocks\Blocks();
+	}
 
-    /**
-     * Only allow the Gutenberg blocks we actually needed. As of Gutenberg 5.0 this was
-     * the easiest way to disable blocks. Also note that custom blocks need to be added
-     * to this list in order to appear.
-     *
-     * @param array $allowed_blocks Allowed blocks
-     *
-     * @return void
-     */
-    public function allowBlocks($allowed_blocks)
-    {
-        return array(
-            'core/image',
-            'core/paragraph',
-            'core/heading',
-            'core/list',
-            'core/subhead',
-            'core/quote',
-            'core/audio',
-            'core/video',
-            'core/table',
-            'core/freeform',
-            'core/html',
-            'core/preformatted',
-            'core/pullquote',
-            'core/separator',
-            'core/embed',
-            'core-embed/twitter',
-            'core-embed/youtube',
-            'core-embed/facebook',
-            'core-embed/instagram',
-            'core-embed/soundcloud',
-            'core-embed/spotify',
-            'core-embed/vimeo',
-            'core-embed/issuu',
-            'core-embed/imgur',
-            'core-embed/reddit',
-            'core-embed/scribd',
-            'core-embed/slideshare',
-            'core-embed/tumblr'
-        );
-    }
+	/**
+	 * Only allow the Gutenberg blocks we actually needed. As of Gutenberg 5.0 this
+	 * was the easiest way to disable blocks. Also note that custom blocks need to
+	 * be added to this list in order to appear.
+	 *
+	 * @param array $allowed_blocks Allowed blocks.
+	 *
+	 * @return array
+	 */
+	public function allow_blocks( $allowed_blocks ) {
+		return array(
+			'core/image',
+			'core/paragraph',
+			'core/heading',
+			'core/list',
+			'core/subhead',
+			'core/quote',
+			'core/audio',
+			'core/video',
+			'core/table',
+			'core/freeform',
+			'core/html',
+			'core/preformatted',
+			'core/pullquote',
+			'core/separator',
+			'core/embed',
+			'core-embed/twitter',
+			'core-embed/youtube',
+			'core-embed/facebook',
+			'core-embed/instagram',
+			'core-embed/soundcloud',
+			'core-embed/spotify',
+			'core-embed/vimeo',
+			'core-embed/issuu',
+			'core-embed/imgur',
+			'core-embed/reddit',
+			'core-embed/scribd',
+			'core-embed/slideshare',
+			'core-embed/tumblr',
+		);
+	}
 }

--- a/src/Managers/TaxonomiesManager.php
+++ b/src/Managers/TaxonomiesManager.php
@@ -1,65 +1,68 @@
 <?php
 /**
  * Bootstraps settings and configurations for taxonomies.
+ *
+ * @package Skela
  */
+
 namespace Skela\Managers;
 
-class TaxonomiesManager
-{
+/** Class */
+class TaxonomiesManager {
 
-    /**
-     * Runs initialization tasks.
-     *
-     * @return void
-     */
-    public function run()
-    {
-        add_action('init', [$this, 'registerTaxonomies'], 1);
-    }
+	/**
+	 * Runs initialization tasks.
+	 *
+	 * @return void
+	 */
+	public function run() {
+		add_action( 'init', array( $this, 'register_taxonomies' ), 1 );
+	}
 
-    /**
-     * Register taxonomies in WordPress
-     *
-     * @return void
-     */
-    public function registerTaxonomies()
-    {
-        // Register Author Taxonomy
-        $authors_labels = array(
-            'name'                       => _x('Authors', 'Taxonomy General Name', 'text_domain'),
-            'singular_name'              => _x('Author', 'Taxonomy Singular Name', 'text_domain'),
-            'menu_name'                  => __('Authors', 'text_domain'),
-            'all_items'                  => __('All Authors', 'text_domain'),
-            'parent_item'                => __('Parent Author', 'text_domain'),
-            'parent_item_colon'          => __('Parent Author:', 'text_domain'),
-            'new_item_name'              => __('New Author Name', 'text_domain'),
-            'add_new_item'               => __('Add New Author', 'text_domain'),
-            'edit_item'                  => __('Edit Author', 'text_domain'),
-            'update_item'                => __('Update Author', 'text_domain'),
-            'view_item'                  => __('View Author', 'text_domain'),
-            'separate_items_with_commas' => __('Separate authors with commas', 'text_domain'),
-            'add_or_remove_items'        => __('Add or remove authors', 'text_domain'),
-            'choose_from_most_used'      => __('Choose from the most used', 'text_domain'),
-            'popular_items'              => __('Popular Authors', 'text_domain'),
-            'search_items'               => __('Search Authors', 'text_domain'),
-            'not_found'                  => __('Not Found', 'text_domain'),
-            'no_terms'                   => __('No authors', 'text_domain'),
-            'items_list'                 => __('Authors list', 'text_domain'),
-            'items_list_navigation'      => __('Authors list navigation', 'text_domain'),
-        );
-        $authors_args = array(
-            'labels'                     => $authors_labels,
-            'hierarchical'               => false,
-            'public'                     => true,
-            'show_ui'                    => true,
-            'show_in_quick_edit'         => false,
-            'meta_box_cb'                => false,
-            'show_admin_column'          => true,
-            'show_in_nav_menus'          => true,
-            'show_in_rest'               => true,
-            'show_tagcloud'              => true,
-            'query_var'                  => 'authors'
-        );
-        register_taxonomy('author', array('post'), $authors_args);
-    }
+	/**
+	 * Register taxonomies in WordPress
+	 *
+	 * @return void
+	 */
+	public function register_taxonomies() {
+		// Register Author Taxonomy.
+		$authors_labels = array(
+			'name'                       => _x( 'Authors', 'Taxonomy General Name', 'text_domain' ),
+			'singular_name'              => _x( 'Author', 'Taxonomy Singular Name', 'text_domain' ),
+			'menu_name'                  => __( 'Authors', 'text_domain' ),
+			'all_items'                  => __( 'All Authors', 'text_domain' ),
+			'parent_item'                => __( 'Parent Author', 'text_domain' ),
+			'parent_item_colon'          => __( 'Parent Author:', 'text_domain' ),
+			'new_item_name'              => __( 'New Author Name', 'text_domain' ),
+			'add_new_item'               => __( 'Add New Author', 'text_domain' ),
+			'edit_item'                  => __( 'Edit Author', 'text_domain' ),
+			'update_item'                => __( 'Update Author', 'text_domain' ),
+			'view_item'                  => __( 'View Author', 'text_domain' ),
+			'separate_items_with_commas' => __( 'Separate authors with commas', 'text_domain' ),
+			'add_or_remove_items'        => __( 'Add or remove authors', 'text_domain' ),
+			'choose_from_most_used'      => __( 'Choose from the most used', 'text_domain' ),
+			'popular_items'              => __( 'Popular Authors', 'text_domain' ),
+			'search_items'               => __( 'Search Authors', 'text_domain' ),
+			'not_found'                  => __( 'Not Found', 'text_domain' ),
+			'no_terms'                   => __( 'No authors', 'text_domain' ),
+			'items_list'                 => __( 'Authors list', 'text_domain' ),
+			'items_list_navigation'      => __( 'Authors list navigation', 'text_domain' ),
+		);
+
+		$authors_args = array(
+			'labels'             => $authors_labels,
+			'hierarchical'       => false,
+			'public'             => true,
+			'show_ui'            => true,
+			'show_in_quick_edit' => false,
+			'meta_box_cb'        => false,
+			'show_admin_column'  => true,
+			'show_in_nav_menus'  => true,
+			'show_in_rest'       => true,
+			'show_tagcloud'      => true,
+			'query_var'          => 'authors',
+		);
+
+		register_taxonomy( 'author', array( 'post' ), $authors_args );
+	}
 }

--- a/src/Managers/ThemeManager.php
+++ b/src/Managers/ThemeManager.php
@@ -1,250 +1,250 @@
 <?php
 /**
- * Bootstraps WordPress theme related functions, most importantly enqueuing javascript and styles.
+ * Bootstraps WordPress theme related functions, most importantly enqueuing
+ * javascript and styles.
+ *
+ * @package Skela
  */
+
 namespace Skela\Managers;
 
 use Timber\Menu;
 
-class ThemeManager
-{
-    private $managers = [];
+/** Class */
+class ThemeManager {
+	/**
+	 * List of theme managers.
+	 *
+	 * @var array
+	 */
+	private $managers = array();
 
-    /**
-     * Constructor
-     *
-     * @param array $managers Array of managers
-     */
-    public function __construct(array $managers)
-    {
-        $this->managers = $managers;
+	/**
+	 * Constructor
+	 *
+	 * @param array $managers Array of managers.
+	 */
+	public function __construct( array $managers ) {
+		$this->managers = $managers;
 
-        add_filter('timber/context', array($this, 'addWpEnvToContext'));
-        add_filter('timber/context', array($this, 'addThemeVersionToContext'));
-        add_filter('timber/context', array($this, 'addIsHomeToContext'));
-        add_filter('timber/context', array($this, 'addMenusToContext'));
-        add_filter('timber/context', array($this, 'addACFOptionsToContext'));
+		add_filter( 'timber/context', array( $this, 'add_wp_env_to_context' ) );
+		add_filter( 'timber/context', array( $this, 'add_theme_version_to_context' ) );
+		add_filter( 'timber/context', array( $this, 'add_is_home_to_context' ) );
+		add_filter( 'timber/context', array( $this, 'add_menus_to_context' ) );
+		add_filter( 'timber/context', array( $this, 'add_acf_options_to_context' ) );
 
-        add_action('admin_enqueue_scripts', array($this,'enqueueAdminScripts'));
-        add_action('wp_dashboard_setup', array($this, 'addDocumentationWidget'));
-        add_action('admin_init', array($this,'redirectToDocs'), 1);
-        add_action('admin_menu', array($this, 'addDocumentationMenuItem'));
-        add_action('admin_init', array($this,'registerMenus'));
+		add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_admin' ) );
+		add_action( 'wp_dashboard_setup', array( $this, 'add_documentation_widget' ) );
+		add_action( 'admin_init', array( $this, 'redirect_to_docs' ), 1 );
+		add_action( 'admin_menu', array( $this, 'add_documentation_menu_item' ) );
+		add_action( 'admin_init', array( $this, 'register_menus' ) );
 
-        add_action('init', array($this, 'registerOptions'), 1, 3);
+		add_action( 'init', array( $this, 'register_options' ), 1, 3 );
 
-        add_filter('acf/fields/relationship/query', array($this,'post_relationship_query'), 10, 3);
-    }
+		add_filter( 'acf/fields/relationship/query', array( $this, 'post_relationship_query' ), 10, 3 );
+	}
 
-    /**
-     * Runs initialization tasks.
-     *
-     * @return void
-     */
-    public function run()
-    {
-        if (count($this->managers) > 0) {
-            foreach ($this->managers as $manager) {
-                $manager->run();
-            }
-        }
+	/**
+	 * Runs initialization tasks.
+	 *
+	 * @return void
+	 */
+	public function run() {
+		if ( count( $this->managers ) > 0 ) {
+			foreach ( $this->managers as $manager ) {
+				$manager->run();
+			}
+		}
 
+		add_action( 'wp_enqueue_scripts', array( $this, 'enqueue' ), 999 );
+		add_theme_support( 'post-thumbnails' );
+		add_theme_support( 'menus' );
+	}
 
-        add_action('wp_enqueue_scripts', [$this, 'enqueue'], 999);
-        add_theme_support('post-thumbnails');
-        add_theme_support('menus');
-    }
+	/**
+	 * Enqueue javascript using WordPress
+	 *
+	 * @return void
+	 */
+	public function enqueue() {
+		// Remove default Gutenberg CSS.
+		wp_deregister_style( 'wp-block-library' );
 
-    /**
-     * Enqueue javascript using WordPress
-     *
-     * @return void
-     */
-    public function enqueue()
-    {
-        // Remove default Gutenberg CSS
-        wp_deregister_style('wp-block-library');
+		wp_enqueue_script( 'vendor', SKELA_THEME_URL . '/dist/vendor.js', array(), SKELA_THEME_VERSION, true );
 
-        wp_enqueue_script('vendor', SKELA_THEME_URL . '/dist/vendor.js', array(), SKELA_THEME_VERSION, true);
+		// Enqueue custom js file, with cache busting.
+		wp_enqueue_script( 'script.js', SKELA_THEME_URL . '/dist/app.js', array(), SKELA_THEME_VERSION, true );
+	}
 
-        // enqueue custom js file, with cache busting
-        wp_enqueue_script('script.js', SKELA_THEME_URL . '/dist/app.js', array(), SKELA_THEME_VERSION, true);
-    }
+	/**
+	 * Enqueue JS and CSS for WP admin panel
+	 *
+	 * @return void
+	 */
+	public function enqueue_admin() {
+		wp_enqueue_style( 'admin-styles', SKELA_THEME_URL . '/dist/admin.css', array(), SKELA_THEME_VERSION );
 
-    /**
-     * Enqueue JS and CSS for WP admin panel
-     *
-     * @return void
-     */
-    public function enqueueAdminScripts()
-    {
-        wp_enqueue_style('admin-styles', SKELA_THEME_URL . '/dist/admin.css');
+		wp_enqueue_script( 'vendor', SKELA_THEME_URL . '/dist/vendor.js', array(), SKELA_THEME_VERSION, false );
+		wp_enqueue_script( 'admin.js', SKELA_THEME_URL . '/dist/admin.js', array(), SKELA_THEME_VERSION, false );
+	}
 
-        wp_enqueue_script('vendor', SKELA_THEME_URL . '/dist/vendor.js', array(), SKELA_THEME_VERSION, false);
-        wp_enqueue_script('admin.js', SKELA_THEME_URL . '/dist/admin.js', array(), SKELA_THEME_VERSION, false);
-    }
+	/**
+	 * Adds ability to check the environment in a twig file
+	 *
+	 * @param array $context Timber context.
+	 *
+	 * @return array
+	 */
+	public function add_wp_env_to_context( $context ) {
+		$context['wp_env'] = WP_ENV;
+		return $context;
+	}
 
-    /**
-     * Adds ability to check the environment in a twig file
-     *
-     * @param array $context Timber context
-     *
-     * @return array
-     */
-    public function addWpEnvToContext($context)
-    {
-        $context['wp_env'] = WP_ENV;
+	/**
+	 * Expose current theme version to Timber context
+	 *
+	 * @param array $context Timber context.
+	 *
+	 * @return array
+	 */
+	public function add_theme_version_to_context( $context ) {
+		$context['theme_version'] = SKELA_THEME_VERSION;
 
-        return $context;
-    }
+		return $context;
+	}
 
-    /**
-     * Expose current theme version to Timber context
-     *
-     * @param array $context Timber context
-     *
-     * @return array
-     */
-    public function addThemeVersionToContext($context)
-    {
-        $context['theme_version'] = SKELA_THEME_VERSION;
+	/**
+	 * Adds ability to check if we are on the homepage in a twig file
+	 *
+	 * @param array $context Timber context.
+	 *
+	 * @return array
+	 */
+	public function add_is_home_to_context( $context ) {
+		$context['is_home'] = is_home();
 
-        return $context;
-    }
+		return $context;
+	}
 
-    /**
-     * Adds ability to check if we are on the homepage in a twig file
-     *
-     * @param array $context Timber context
-     *
-     * @return array
-     */
-    public function addIsHomeToContext($context)
-    {
-        $context['is_home'] = is_home();
-
-        return $context;
-    }
-
-    /**
-     * Register nav menus
-     *
-     * @return void
-     */
-    public function registerMenus()
-    {
-        register_nav_menus(
-            array(
-                'nav_topics_menu' => 'Navigation Topics Menu',
-                'nav_pages_menu' => 'Navigation Pages Menu',
-                )
-        );
-    }
+	/**
+	 * Register nav menus
+	 *
+	 * @return void
+	 */
+	public function register_menus() {
+		register_nav_menus(
+			array(
+				'nav_topics_menu' => 'Navigation Topics Menu',
+				'nav_pages_menu'  => 'Navigation Pages Menu',
+			)
+		);
+	}
 
 
-    /**
-     * Registers and adds menus to context
-     *
-     * @param array $context Timber context
-     *
-     * @return array
-     */
-    public function addMenusToContext($context)
-    {
-        $context['nav_topics_menu'] = new Menu('nav_topics_menu');
-        $context['nav_pages_menu'] = new Menu('nav_pages_menu');
-        return $context;
-    }
+	/**
+	 * Registers and adds menus to context
+	 *
+	 * @param array $context Timber context.
+	 *
+	 * @return array
+	 */
+	public function add_menus_to_context( $context ) {
+		$context['nav_topics_menu'] = new Menu( 'nav_topics_menu' );
+		$context['nav_pages_menu']  = new Menu( 'nav_pages_menu' );
+		return $context;
+	}
 
-    /**
-     * Adds a widget to the dashboard with a link to editor docs
-     *
-     * @return void
-     */
-    public function addDocumentationWidget()
-    {
-        wp_add_dashboard_widget(
-            'custom_dashboard_widget',
-            'Editor Documentation',
-            function () {
-                echo "<p><a href='/wp-content/themes/skela/documentation/index.html' target='_blank' rel='noopener noreferrer'>View</a> the editor documentation</p>";
-            }
-        );
-    }
+	/**
+	 * Adds a widget to the dashboard with a link to editor docs
+	 *
+	 * @return void
+	 */
+	public function add_documentation_widget() {
+		wp_add_dashboard_widget(
+			'custom_dashboard_widget',
+			'Editor Documentation',
+			function () {
+				echo "<p><a href='/wp-content/themes/skela/documentation/index.html' target='_blank' rel='noopener noreferrer'>View</a> the editor documentation</p>";
+			}
+		);
+	}
 
-    /**
-     * Adds a menu item to WP admin that links to editor docs
-     *
-     * @return void
-     */
-    public function addDocumentationMenuItem()
-    {
-        add_menu_page('Editor Docs', 'Editor Docs', 'manage_options', 'link-to-docs', array($this,'redirectToDocs'), 'dashicons-admin-links', 100);
-    }
+	/**
+	 * Adds a menu item to WP admin that links to editor docs
+	 *
+	 * @return void
+	 */
+	public function add_documentation_menu_item() {
+		add_menu_page(
+			'Editor Docs',
+			'Editor Docs',
+			'manage_options',
+			'link-to-docs',
+			array( $this, 'redirect_to_docs' ),
+			'dashicons-admin-links',
+			100
+		);
+	}
 
 
-    /**
-     * To have an external link to the docs we need this weird function
-     *
-     * @return void
-     */
-    public function redirectToDocs()
-    {
-        $menu_redirect = isset($_GET['page']) ? $_GET['page'] : false;
-        if ($menu_redirect == 'link-to-docs') {
-            header('Location: https://' . $_SERVER['HTTP_HOST'] . '/wp-content/themes/skela/documentation');
-            exit();
-        }
-    }
+	/**
+	 * To have an external link to the docs we need this weird function
+	 *
+	 * @return void
+	 */
+	public function redirect_to_docs() {
+		$menu_redirect = isset( $_GET['page'] ) ? $_GET['page'] : false;
+		if ( 'link-to-docs' === $menu_redirect ) {
+			header( 'Location: https://' . $_SERVER['HTTP_HOST'] . '/wp-content/themes/skela/documentation' );
+			exit();
+		}
+	}
 
-    /**
-     * Add ACF options page to WordPress
-     *
-     * @return void
-     */
-    public function registerOptions()
-    {
-        if (function_exists('acf_add_options_page')) {
-            acf_add_options_page(
-                array(
-                'page_title'  => 'Site Settings',
-                'menu_title'  => 'Site Settings',
-                'menu_slug'   => 'site-settings'
-                )
-            );
-        }
-    }
+	/**
+	 * Add ACF options page to WordPress
+	 *
+	 * @return void
+	 */
+	public function register_options() {
+		if ( function_exists( 'acf_add_options_page' ) ) {
+			acf_add_options_page(
+				array(
+					'page_title' => 'Site Settings',
+					'menu_title' => 'Site Settings',
+					'menu_slug'  => 'site-settings',
+				)
+			);
+		}
+	}
 
-    /**
-     * Adds ability to access array of ACF options fields in a twig field
-     *
-     * @param array $context Timber context
-     *
-     * @return array
-     */
-    public function addACFOptionsToContext($context)
-    {
-        if (class_exists('acf')) {
-            $context["options"] = get_fields('option');
-        }
-        return $context;
-    }
+	/**
+	 * Adds ability to access array of ACF options fields in a twig field
+	 *
+	 * @param array $context Timber context.
+	 *
+	 * @return array
+	 */
+	public function add_acf_options_to_context( $context ) {
+		if ( class_exists( 'acf' ) ) {
+			$context['options'] = get_fields( 'option' );
+		}
+		return $context;
+	}
 
-    /**
-     * Modify ACF relationship field to show most recent posts instead of alpha
-     *
-     * @param array  $args    Args
-     * @param string $field   Field
-     * @param int    $post_id Post ID
-     *
-     * @return void
-     */
-    public function post_relationship_query($args, $field, $post_id)
-    {
-        // order returned query collection by date, starting with most recent
-        $args['order'] = 'DESC';
-        $args['orderby'] = 'post_date';
+	/**
+	 * Modify ACF relationship field to show most recent posts instead of alpha
+	 *
+	 * @param array  $args    Args.
+	 * @param string $field   Field.
+	 * @param int    $post_id Post ID.
+	 *
+	 * @return array
+	 */
+	public function post_relationship_query( $args, $field, $post_id ) {
+		// Order returned query collection by date, starting with most recent.
+		$args['order']   = 'DESC';
+		$args['orderby'] = 'post_date';
 
-        return $args;
-    }
+		return $args;
+	}
 }

--- a/src/Managers/WordPressManager.php
+++ b/src/Managers/WordPressManager.php
@@ -1,102 +1,105 @@
 <?php
 /**
  * Mostly involved with cleaning up default WordPress cruft.
+ *
+ * @package Skela
  */
+
 namespace Skela\Managers;
 
-class WordPressManager
-{
+/** Class */
+class WordPressManager {
 
-    /**
-     * Runs initialization tasks.
-     *
-     * @return void
-     */
-    public function run()
-    {
-        add_action('wp_loaded', [$this, 'cleanup'], 1);
-        add_action('wp_dashboard_setup', array($this, 'removeDashboardWidgets'));
-    }
+	/**
+	 * Runs initialization tasks.
+	 *
+	 * @return void
+	 */
+	public function run() {
+		add_action( 'wp_loaded', array( $this, 'cleanup' ), 1 );
+		add_action( 'wp_dashboard_setup', array( $this, 'remove_dashboard_widgets' ) );
+	}
 
-    /**
-     * Cleans up and removes unnecessary Wordpress bloat.
-     *
-     * @return void
-     */
-    public function cleanup()
-    {
-        remove_action('template_redirect', 'rest_output_link_header', 11, 0);
-        remove_action('template_redirect', 'wp_shortlink_header', 11);
-        remove_action('wp_head', 'adjacent_posts_rel_link_wp_head', 10);
-        remove_action('wp_head', 'feed_links', 2);
-        remove_action('wp_head', 'feed_links_extra', 3);
-        remove_action('wp_head', 'noindex', 1);
-        remove_action('wp_head', 'parent_post_rel_link');
-        remove_action('wp_head', 'print_emoji_detection_script', 7);
-        remove_action('wp_head', 'rel_canonical');
-        remove_action('wp_head', 'rest_output_link_wp_head');
-        remove_action('wp_head', 'rsd_link');
-        remove_action('wp_head', 'start_post_rel_link');
-        remove_action('wp_head', 'wlwmanifest_link');
-        remove_action('wp_head', 'wp_oembed_add_discovery_links');
-        remove_action('wp_head', 'wp_oembed_add_host_js');
-        remove_action('wp_head', 'wp_generator');
-        remove_action('wp_head', 'wp_resource_hints', 2);
-        remove_action('wp_head', 'wp_shortlink_wp_head');
-        remove_action('wp_print_styles', 'print_emoji_styles');
+	/**
+	 * Cleans up and removes unnecessary WordPress bloat.
+	 *
+	 * @return void
+	 */
+	public function cleanup() {
+		remove_action( 'template_redirect', 'rest_output_link_header', 11, 0 );
+		remove_action( 'template_redirect', 'wp_shortlink_header', 11 );
+		remove_action( 'wp_head', 'adjacent_posts_rel_link_wp_head', 10 );
+		remove_action( 'wp_head', 'feed_links', 2 );
+		remove_action( 'wp_head', 'feed_links_extra', 3 );
+		remove_action( 'wp_head', 'noindex', 1 );
+		remove_action( 'wp_head', 'parent_post_rel_link' );
+		remove_action( 'wp_head', 'print_emoji_detection_script', 7 );
+		remove_action( 'wp_head', 'rel_canonical' );
+		remove_action( 'wp_head', 'rest_output_link_wp_head' );
+		remove_action( 'wp_head', 'rsd_link' );
+		remove_action( 'wp_head', 'start_post_rel_link' );
+		remove_action( 'wp_head', 'wlwmanifest_link' );
+		remove_action( 'wp_head', 'wp_oembed_add_discovery_links' );
+		remove_action( 'wp_head', 'wp_oembed_add_host_js' );
+		remove_action( 'wp_head', 'wp_generator' );
+		remove_action( 'wp_head', 'wp_resource_hints', 2 );
+		remove_action( 'wp_head', 'wp_shortlink_wp_head' );
+		remove_action( 'wp_print_styles', 'print_emoji_styles' );
 
-        add_filter('json_enabled', '__return_false');
-        add_filter('json_jsonp_enabled', '__return_false');
-        add_filter('xmlrpc_enabled', '__return_false');
+		add_filter( 'json_enabled', '__return_false' );
+		add_filter( 'json_jsonp_enabled', '__return_false' );
+		add_filter( 'xmlrpc_enabled', '__return_false' );
 
-        // Remove pingbacks from cron jobs.
-        if (defined('DOING_CRON') && DOING_CRON) {
-            remove_action('do_pings', 'do_all_pings');
-            wp_clear_scheduled_hook('do_pings');
-        }
-    }
+		// Remove pingbacks from cron jobs.
+		if ( defined( 'DOING_CRON' ) && DOING_CRON ) {
+			remove_action( 'do_pings', 'do_all_pings' );
+			wp_clear_scheduled_hook( 'do_pings' );
+		}
+	}
 
-    /**
-     * Forces REST endpoints to be accessed only by logged in users. See
-     * https://developer.wordpress.org/rest-api/using-the-rest-api/frequently-asked-questions/#require-authentication-for-all-requests
-     *
-     * @return void
-     */
-    public function requireRestAuth()
-    {
-        add_filter(
-            'rest_authentication_errors',
-            function ($result) {
-                if (!empty($result)) {
-                    return $result;
-                }
+	/**
+	 * Forces REST endpoints to be accessed only by logged in users. See
+	 * https://developer.wordpress.org/rest-api/using-the-rest-api/frequently-asked-questions/#require-authentication-for-all-requests
+	 *
+	 * @return void
+	 */
+	public function require_rest_auth() {
+		add_filter(
+			'rest_authentication_errors',
+			function ( $result ) {
+				if ( ! empty( $result ) ) {
+					return $result;
+				}
 
-                if (!is_user_logged_in()) {
-                    return new WP_Error('rest_not_logged_in', 'You are not currently logged in.', ['status' => 401]);
-                }
+				if ( ! is_user_logged_in() ) {
+					return new WP_Error(
+						'rest_not_logged_in',
+						'You are not currently logged in.',
+						array( 'status' => 401 )
+					);
+				}
 
-                return $result;
-            }
-        );
-    }
+				return $result;
+			}
+		);
+	}
 
-    /**
-     * Hide extranneous dashboard widgets
-     *
-     * @return void
-     */
-    public function removeDashboardWidgets()
-    {
-        global $wp_meta_boxes;
+	/**
+	 * Hide extranneous dashboard widgets
+	 *
+	 * @return void
+	 */
+	public function remove_dashboard_widgets() {
+		global $wp_meta_boxes;
 
-        unset($wp_meta_boxes['dashboard']['side']['core']['dashboard_quick_press']);
-        unset($wp_meta_boxes['dashboard']['normal']['core']['dashboard_incoming_links']);
-        unset($wp_meta_boxes['dashboard']['normal']['core']['dashboard_right_now']);
-        unset($wp_meta_boxes['dashboard']['normal']['core']['dashboard_plugins']);
-        unset($wp_meta_boxes['dashboard']['normal']['core']['dashboard_recent_drafts']);
-        unset($wp_meta_boxes['dashboard']['normal']['core']['dashboard_recent_comments']);
-        unset($wp_meta_boxes['dashboard']['side']['core']['dashboard_primary']);
-        unset($wp_meta_boxes['dashboard']['side']['core']['dashboard_secondary']);
-        unset($wp_meta_boxes['dashboard']['normal']['core']['yoast_db_widget']);
-    }
+		unset( $wp_meta_boxes['dashboard']['side']['core']['dashboard_quick_press'] );
+		unset( $wp_meta_boxes['dashboard']['normal']['core']['dashboard_incoming_links'] );
+		unset( $wp_meta_boxes['dashboard']['normal']['core']['dashboard_right_now'] );
+		unset( $wp_meta_boxes['dashboard']['normal']['core']['dashboard_plugins'] );
+		unset( $wp_meta_boxes['dashboard']['normal']['core']['dashboard_recent_drafts'] );
+		unset( $wp_meta_boxes['dashboard']['normal']['core']['dashboard_recent_comments'] );
+		unset( $wp_meta_boxes['dashboard']['side']['core']['dashboard_primary'] );
+		unset( $wp_meta_boxes['dashboard']['side']['core']['dashboard_secondary'] );
+		unset( $wp_meta_boxes['dashboard']['normal']['core']['yoast_db_widget'] );
+	}
 }

--- a/src/Models/SkelaPost.php
+++ b/src/Models/SkelaPost.php
@@ -1,23 +1,24 @@
 <?php
-
 /**
- * Additional functionality for extending the TimberPost object
+ * Additional functionality for extending the TimberPost object.
+ *
+ * @package Skela
  */
+
 namespace Skela\Models;
 
 use Timber\Post;
 use Timber\Timber;
 use Timber\Image;
 
-class SkelaPost extends Post
-{
-    /**
-     * Example Function
-     *
-     * @return void
-     */
-    public function getFormattedAuthors()
-    {
-        return "Jane Doe, Roger Smith";
-    }
+/** Class */
+class SkelaPost extends Post {
+	/**
+	 * Example Function
+	 *
+	 * @return string
+	 */
+	public function get_formatted_authors() {
+		return 'Jane Doe, Roger Smith';
+	}
 }

--- a/src/Repositories/PostTypeRepository.php
+++ b/src/Repositories/PostTypeRepository.php
@@ -1,7 +1,10 @@
 <?php
 /**
  * Repository entity for retrieving post type objects.
+ *
+ * @package Skela
  */
+
 namespace Skela\Repositories;
 
 use WP_Query;
@@ -12,120 +15,132 @@ use Timber\Post;
 use Timber\PostCollection;
 use Timber\PostQuery;
 
-class PostTypeRepository extends Repository
-{
-    const POST_TYPES = ['post']; // Main post types
+/** Class */
+class PostTypeRepository extends Repository {
+	const POST_TYPES = array( 'post' ); // Main post types.
 
-    /**
-     * Returns a chronological list of latest "Post" (articles) posts for a given category.
-     * Default $limit is 10.
-     *
-     * @param string|array $slug    Slug
-     * @param integer      $limit   Number to return (optional)
-     * @param array        $exclude Posts to exclude (optional)
-     * @param integer      $paged   Enable pagination (optional)
-     *
-     * @return Repository
-     */
-    public function articlesByCategorySlug($slug, $limit = 10, $exclude = [], $paged = 0)
-    {
+	/**
+	 * Returns a chronological list of latest "Post" (articles) posts for a given
+	 * category. Default $limit is 10.
+	 *
+	 * @param string|array $slug    Slug.
+	 * @param integer      $limit   Number to return (optional).
+	 * @param array        $exclude Posts to exclude (optional).
+	 * @param integer      $paged   Enable pagination (optional).
+	 *
+	 * @return Repository
+	 */
+	public function articles_by_category_slug( $slug, $limit = 10, $exclude = array(), $paged = 0 ) {
 
-        // Set sane defaults so we don't do full table scans.
-        if ($limit <= 0 || $limit > 1000) {
-            $limit = 1000;
-        }
+		// Set sane defaults so we don't do full table scans.
+		if ( $limit <= 0 || $limit > 1000 ) {
+			$limit = 1000;
+		}
 
-        // Note the + symbol. See https://codex.wordpress.org/Class_Reference/WP_Query#Category_Parameters
-        if (is_array($slug)) {
-            $slug = implode('+', $slug);
-        }
+		// Note the + symbol. See https://codex.wordpress.org/Class_Reference/WP_Query#Category_Parameters.
+		if ( is_array( $slug ) ) {
+			$slug = implode( '+', $slug );
+		}
 
-        $params = ['posts_per_page' => (int)$limit,
-                   'category_name' => $slug,
-                   'post_type' => 'post',
-                   'post_status' => 'publish',
-                   'orderby' => 'date',
-                   'order' => 'DESC'];
+		$params = array(
+			'posts_per_page' => (int) $limit,
+			'category_name'  => $slug,
+			'post_type'      => 'post',
+			'post_status'    => 'publish',
+			'orderby'        => 'date',
+			'order'          => 'DESC',
+		);
 
-        if (is_array($exclude) && count($exclude) > 0) {
-            $params['post__not_in'] = $exclude;
-        }
+		if ( is_array( $exclude ) && count( $exclude ) > 0 ) {
+			$params['post__not_in'] = $exclude;
+		}
 
-        if ((int)$paged > 0) {
-            $params['paged'] = $paged;
-        }
+		if ( (int) $paged > 0 ) {
+			$params['paged'] = $paged;
+		}
 
-        return $this->query($params);
-    }
+		return $this->query( $params );
+	}
 
-    /**
-     * Returns list of "Posts" between the specified date ranges. $endDate defaults to now if
-     * null.
-     *
-     * @param Carbon  $startDate Start date
-     * @param Carbon  $endDate   End date
-     * @param integer $paged     Enable pagination
-     *
-     * @return Repository
-     */
-    public function articlesByDateRange(Carbon $startDate, Carbon $endDate = null, $paged = 0)
-    {
-        if ($endDate == null) {
-            $endDate = Carbon::now();
-        }
+	/**
+	 * Returns list of "Posts" between the specified date ranges. $end_datae defaults
+	 * to now if null.
+	 *
+	 * @param Carbon  $start_date Start date.
+	 * @param Carbon  $end_datae  End date.
+	 * @param integer $paged      Enable pagination.
+	 *
+	 * @return Repository
+	 */
+	public function articles_by_date_range( Carbon $start_date, Carbon $end_datae = null, $paged = 0 ) {
+		if ( null === $end_datae ) {
+			$end_datae = Carbon::now();
+		}
 
-        $dateQuery = [
-            'after' => ['year' => $startDate->year, 'month' => $startDate->month, 'day' => $startDate->day],
-            'before' => ['year' => $endDate->year, 'month' => $endDate->month, 'day' => $endDate->day],
-            'inclusive' => true
-        ];
+		$date_query = array(
+			'after'     => array(
+				'year'  => $start_date->year,
+				'month' => $start_date->month,
+				'day'   => $start_date->day,
+			),
+			'before'    => array(
+				'year'  => $end_datae->year,
+				'month' => $end_datae->month,
+				'day'   => $end_datae->day,
+			),
+			'inclusive' => true,
+		);
 
-        $params = ['date_query' => $dateQuery,
-                   'posts_per_page' => -1,
-                   'post_type' => 'post',
-                   'post_status' => 'publish',
-                   'orderby' => 'date',
-                   'order' => 'DESC'];
+		$params = array(
+			'date_query'     => $date_query,
+			'posts_per_page' => -1,
+			'post_type'      => 'post',
+			'post_status'    => 'publish',
+			'orderby'        => 'date',
+			'order'          => 'DESC',
+		);
 
-        if ((int)$paged > 0) {
-            $params['paged'] = $paged;
-        }
+		if ( (int) $paged > 0 ) {
+			$params['paged'] = $paged;
+		}
 
-        return $this->query($params);
-    }
+		return $this->query( $params );
+	}
 
-    /**
-     * Returns a chronological list of latest posts across all *public* post types. This
-     * acts as a "firehose" of new content so to speak.
-     *
-     * @param integer $limit    Number of posts to return
-     * @param array   $postType WordPress post types
-     * @param array   $exclude  IDs of posts to exclude
-     * @param integer $paged    Enable pagination
-     *
-     * @return Repository
-     */
-    public function latestPosts($limit = 10, $postType = self::POST_TYPES, array $exclude = [], $paged = 0)
-    {
+	/**
+	 * Returns a chronological list of latest posts across all *public* post types.
+	 * This acts as a "firehose" of new content so to speak.
+	 *
+	 * @param integer $limit      Number of posts to return.
+	 * @param array   $post_types WordPress post types.
+	 * @param array   $exclude    IDs of posts to exclude.
+	 * @param integer $paged      Enable pagination.
+	 *
+	 * @return Repository
+	 */
+	public function latest_posts( $limit = 10, $post_types = self::POST_TYPES, array $exclude = array(), $paged = 0 ) {
 
-        // Set sane defaults so we don't do full table scans.
-        if ($limit <= 0 || $limit > 1000) {
-            $limit = 1000;
-        }
+		// Set sane defaults so we don't do full table scans.
+		if ( $limit <= 0 || $limit > 1000 ) {
+			$limit = 1000;
+		}
 
-        $params = ['posts_per_page' => (int)$limit,
-                   'post_status' => 'publish',
-                   'orderby' => 'date',
-                   'order' => 'DESC'];
+		$params = array(
+			'posts_per_page' => (int) $limit,
+			'post_type'      => $post_types,
+			'post_status'    => 'publish',
+			'orderby'        => 'date',
+			'order'          => 'DESC',
+		);
 
-        if (count($exclude) > 0) {
-            $params['post__not_in'] = $exclude;
-        }
+		if ( count( $exclude ) > 0 ) {
+			$params['post__not_in'] = $exclude;
+		}
 
-        if ((int)$paged > 0) {
-            $params['paged'] = $paged;
-        }
+		if ( (int) $paged > 0 ) {
+			$params['paged'] = $paged;
+		}
 
-        return $this->query($params);
-    }
+		return $this->query( $params );
+	}
 }

--- a/src/Services/WordPressService.php
+++ b/src/Services/WordPressService.php
@@ -1,55 +1,61 @@
 <?php
 /**
- * Wordpress specific related functions
+ * WordPress specific related functions.
+ *
+ * @package Skela
  */
+
 namespace Skela\Services;
 
-class WordPressService
-{
-    /**
-     * Force an abort of a HTTP request
-     *
-     * @param integer $statusCode HTTP status code number
-     *
-     * @return void
-     */
-    public static function abort_request($statusCode = 0)
-    {
+/** Class */
+class WordPressService {
 
-        // Always reset the content type.
-        add_filter(
-            'wp_headers',
-            function ($headers) {
-                $headers['Content-Type'] = 'text/html';
-                return $headers;
-            },
-            99,
-            1
-        );
+	/**
+	 * Force an abort of a HTTP request
+	 *
+	 * @param integer $status_code HTTP status code number.
+	 *
+	 * @return void
+	 */
+	public static function abort_request( $status_code = 0 ) {
 
-        // ...reset in nocache_headers as well.
-        add_filter(
-            'nocache_headers',
-            function ($headers) {
-                $headers['Content-Type'] = 'text/html';
-                return $headers;
-            },
-            99,
-            1
-        );
+		// Always reset the content type.
+		add_filter(
+			'wp_headers',
+			function ( $headers ) {
+				$headers['Content-Type'] = 'text/html';
+				return $headers;
+			},
+			99,
+			1
+		);
 
-        switch ($statusCode) {
-        case 403:
-            wp_die('Error: Access forbidden.', 'Access Forbidden - ' . SKELA_SITE_NAME, ['response' => 403]);
+		// ...reset in nocache_headers as well.
+		add_filter(
+			'nocache_headers',
+			function ( $headers ) {
+				$headers['Content-Type'] = 'text/html';
+				return $headers;
+			},
+			99,
+			1
+		);
 
-            // no break
-        case 404:
-            global $wp_query;
-            $wp_query->set_404();
-            status_header(404);
-            nocache_headers();
-            include get_query_template('404');
-            exit;
-        }
-    }
+		switch ( $status_code ) {
+			case 403:
+				wp_die(
+					'Error: Access forbidden.',
+					'Access Forbidden',
+					array( 'response' => 403 )
+				);
+				// no break.
+			case 404:
+				global $wp_query;
+				$wp_query->set_404();
+				status_header( 404 );
+				nocache_headers();
+				include get_query_template( '404' );
+				exit;
+		}
+	}
 }


### PR DESCRIPTION
## Changes

This PR proposes to update our PHP code style to align with the [WordPress standards](https://github.com/WordPress/WordPress-Coding-Standards). It also aligns all of our PHP files to this new standard.

I'm sorry in advance for all of the strict linting rules.

## How To Test

1. Pull down this branch.
1. Run `composer update` to install the WordPress coding standards sniffs.
1. Make sure there are no linting errors.

## PHP linting and VSCode

I use the [phpcs extension](https://marketplace.visualstudio.com/items?itemName=ikappas.phpcs) for VSCode to help display linting errors. The instructions in that package are pretty good to get up and running.