### PR TITLE
Add root php files to linter

### DIFF
--- a/front-page.php
+++ b/front-page.php
@@ -9,8 +9,8 @@ use Skela\Repositories\PostTypeRepository;
 
 $context = Timber::context();
 
-$post_repo = new PostTypeRepository();
-$latest_posts = $post_repo->latest_posts( 10, null, [], null )->get();
+$post_repo        = new PostTypeRepository();
+$latest_posts     = $post_repo->latest_posts( 10, null, array(), null )->get();
 $context['posts'] = $latest_posts;
 
 // Render view.

--- a/functions.php
+++ b/functions.php
@@ -27,7 +27,7 @@ Dotenv\Dotenv::create( __DIR__ )->safeLoad();
  * Set up our global environment constant and load its config first
  * Default: production
  */
-define( 'WP_ENV', getenv( 'WP_ENV' ) ?: 'production' );
+define( 'WP_ENV', getenv( 'WP_ENV' ) ? getenv( 'WP_ENV' ) : 'production' );
 
 $timber = new Timber\Timber();
 Timber::$dirname = array( 'templates' );
@@ -35,12 +35,12 @@ Timber::$dirname = array( 'templates' );
 add_action(
 	'after_setup_theme',
 	function () {
-		$managers = [
+		$managers = array(
 			/* new \Skela\Managers\TaxonomiesManager(), */
 			new \Skela\Managers\WordPressManager(),
 			new \Skela\Managers\GutenbergManager(),
 			new \Skela\Managers\CustomPostsManager(),
-		];
+		);
 
 		if ( function_exists( 'acf_add_local_field_group' ) ) {
 			$managers[] = new \Skela\Managers\ACFManager();

--- a/page.php
+++ b/page.php
@@ -5,10 +5,8 @@
  * @package Skela
  */
 
-$context = Timber::context();
-
-$page = Timber::get_post();
-
-$context['page'] = $page;
+$context         = Timber::context();
+$_page           = Timber::get_post();
+$context['page'] = $_page;
 
 Timber::render( 'pages/page.twig', $context );

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -5,6 +5,14 @@
   <!-- Where to sniff -->
   <file>./src/</file>
 
+  <!-- Optionally add the template files in the root -->
+  <file>./404.php</file>
+  <file>./front-page.php</file>
+  <file>./functions.php</file>
+  <file>./index.php</file>
+  <file>./page.php</file>
+  <file>./single.php</file>
+
   <exclude-pattern>*.js</exclude-pattern>
   <exclude-pattern>*.css</exclude-pattern>
 

--- a/single.php
+++ b/single.php
@@ -5,10 +5,8 @@
  * @package Skela
  */
 
-$context = Timber::context();
-
-$post = Timber::get_post();
-
-$context['article'] = $post;
+$context            = Timber::context();
+$_post              = Timber::get_post();
+$context['article'] = $_post;
 
 Timber::render( 'pages/article.twig', $context );


### PR DESCRIPTION
This PR adds the `./*php` files at the root of the theme to the `phpcs` linter. These files are important to lint because we have generally set up variables names either `$post` or `$page` here, which overrides WordPress globals and can cause issues. By including these files in the linter that will flagged and notify you if you're trying to override a WordPress global.

It is recommended to use a leading underscore for variables (`$_post` or `$_page`) when custom querying for posts or pages.