### PR TITLE
Fix license name in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     }
   ],
   "description": "WordPress theme",
-  "license": "proprietary",
+  "license": "MIT",
   "repositories": [
     {
       "type": "composer",


### PR DESCRIPTION
## Changes

Fix license name.

https://github.com/Upstatement/skela-wp-theme/blob/1fb41ec3564c3961e2bf126ea87b1e3a5e73413d/LICENSE#L1
